### PR TITLE
fix: tidy layout script section

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -1,4 +1,3 @@
-
 ---
 const { title = "Pecin Design — Portfólio", description = "Direção de arte, identidade visual, campanhas e motion design." } = Astro.props;
 ---


### PR DESCRIPTION
## Summary
- refine layout script tag, defining default title and description in one line

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ccaff2068832798620a83b3e3547a