### PR TITLE
Configure contact form endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PUBLIC_FORM_ENDPOINT="https://formsubmit.co/test@example.com"

--- a/src/pages/contato/index.astro
+++ b/src/pages/contato/index.astro
@@ -1,12 +1,13 @@
 
 ---
 import Layout from '../../components/Layout.astro';
+const action = import.meta.env.PUBLIC_FORM_ENDPOINT || 'https://formsubmit.co/test@example.com';
 ---
 <Layout>
   <section class="max-w-4xl mx-auto px-4 py-16 text-center">
     <h1 class="text-3xl font-bold mb-6">Contato</h1>
     <p class="text-gray-700 mb-8">Vamos conversar sobre seu projeto.</p>
-    <form action="https://formspree.io/f/SEU_ENDPOINT" method="POST" class="grid gap-4 max-w-md mx-auto">
+    <form action={action} method="POST" class="grid gap-4 max-w-md mx-auto">
       <input type="text" name="nome" placeholder="Seu nome" required class="border rounded px-3 py-2">
       <input type="email" name="email" placeholder="Seu email" required class="border rounded px-3 py-2">
       <textarea name="mensagem" placeholder="Sua mensagem" required class="border rounded px-3 py-2 h-32"></textarea>


### PR DESCRIPTION
## Summary
- replace placeholder form action with configurable endpoint
- provide `.env.example` with contact form endpoint variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PUBLIC_FORM_ENDPOINT=https://formsubmit.co/test@example.com npm run build`
- `curl -s -L -H 'Origin: https://example.com' -H 'Referer: https://example.com' -H 'User-Agent: Mozilla/5.0' -d 'name=Test&message=Hi' https://formsubmit.co/test@example.com | rg -n 'Check Your Email' -n`


------
https://chatgpt.com/codex/tasks/task_e_688cd656481483279c9d3099d98fd16b